### PR TITLE
[BUGFIX] Cache flush task with argument "--force" instead of "true"

### DIFF
--- a/src/Console/CacheFlushTask.php
+++ b/src/Console/CacheFlushTask.php
@@ -48,7 +48,7 @@ class CacheFlushTask extends AbstractConsoleTask
         );
         $command = sprintf(
             $this->getConsoleCommand('cache:flush', $options).'%s',
-            !empty($options['force-flush-cache']) ? 'true' : ''
+            !empty($options['force-flush-cache']) ? '--force' : ''
         );
 
         return $this->executeCommand($command);

--- a/tests/Task/Console/CacheFlushTaskTest.php
+++ b/tests/Task/Console/CacheFlushTaskTest.php
@@ -46,7 +46,7 @@ class CacheFlushTaskTest extends TestCase
                 'yaml'     => 'consoleCacheFlushForce.yml',
                 'expected' => [
                     'rsync -e "ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" -avz --exclude=.git --exclude=./var/cache/* --exclude=./var/log/* --exclude=./web/app_dev.php ./ tester@testhost:/var/www/test',
-                    'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test && vendor/bin/typo3cms cache:flush true"'
+                    'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test && vendor/bin/typo3cms cache:flush --force"'
                 ]
             ],
             'cache flush custom console path'       => [


### PR DESCRIPTION
Cache flush task now supports the new argument "--force" instead of using the old argument "true"